### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ npm run preview
 
 ## Distribuzione su GitHub Pages
 
+La repository include un workflow GitHub Actions (`Deploy to GitHub Pages`) che, a ogni push sul branch `main`, installa le dipendenze, esegue `npm run build` e pubblica automaticamente il contenuto della cartella `dist/` su GitHub Pages. È comunque possibile avviare manualmente il workflow dalla sezione "Actions" della repository.
+
+Se preferisci un deploy manuale:
+
 1. Esegui `npm run build`.
 2. Pubblica il contenuto della cartella `dist/` sul branch GitHub Pages (ad esempio `gh-pages`).
-3. Assicurati che la repository utilizzi il percorso `/` oppure configura Pages per servire dal root della build; la configurazione Vite utilizza `base: './'` per garantire percorsi relativi compatibili.
+3. Assicurati che la repository utilizzi il percorso `/grid-conquest/` su Pages; la configurazione Vite con `base: './'` genera percorsi relativi compatibili con il progetto.
 
 ## Struttura principale del progetto
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the project and deploys the dist output to GitHub Pages on every push to main
- document the automated workflow and manual deployment steps in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3e2f4d5e883308d2d908d5a7158a5