### PR TITLE
Fix GitHub Pages deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,38 +2,39 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
   workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Build project
+      - name: Build
         run: npm run build
 
-      - name: Upload build artifact
+      - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 
 export default defineConfig({
-  base: "./",
+  base: "/grid-conquest/",
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- set the Vite base path to match the repository name so built assets resolve correctly on GitHub Pages
- add a GitHub Actions workflow that builds the site and deploys the `dist` output to GitHub Pages on every push to main

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f0806800833083a652f5b6be4c8c