### PR TITLE
Fix GitHub Pages deployment manifest issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,9 @@ jobs:
           node-version: 20
           cache: 'npm'
 
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v4
+
       - name: Install dependencies
         run: npm ci
 

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,7 +1,8 @@
 {
   "name": "Grid Conquest",
   "short_name": "GridConquest",
-  "start_url": ".",
+  "start_url": "/grid-conquest/",
+  "scope": "/grid-conquest/",
   "display": "standalone",
   "background_color": "#0f172a",
   "theme_color": "#1d4ed8",


### PR DESCRIPTION
## Summary
- configure the Pages workflow to use actions/configure-pages so GitHub Pages serves the built bundle
- update the web manifest scope and start URL to the published /grid-conquest/ path for correct asset resolution

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f2ca2c488330bab067d9ecca4c9f