### PR TITLE
Improve mobile cell layout

### DIFF
--- a/src/components/CellTile.tsx
+++ b/src/components/CellTile.tsx
@@ -23,12 +23,21 @@ export function CellTile({ cell, isSelected, lastAction, onClick }: CellTileProp
 
   const conquered = lastAction?.toId === cell.id;
   const origin = lastAction?.fromId === cell.id;
+  const ownerLabel =
+    cell.owner === "player"
+      ? "Comandante"
+      : cell.owner === "ai"
+      ? "IA"
+      : cell.type === "resource"
+      ? "Risorsa"
+      : "Neutrale";
+  const icon = typeIcon[cell.type];
 
   return (
     <button
       onClick={onClick}
       className={clsx(
-        "relative aspect-square rounded-xl border backdrop-blur-sm transition-transform duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300",
+        "relative aspect-square overflow-hidden rounded-xl border backdrop-blur-sm transition-transform duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300",
         ownerClass,
         conquered && "animate-conquer",
         origin && "animate-pulseGlow",
@@ -38,13 +47,15 @@ export function CellTile({ cell, isSelected, lastAction, onClick }: CellTileProp
           : "hover:scale-[0.99]"
       )}
     >
-      <div className="flex h-full w-full flex-col items-center justify-center gap-1 p-1 text-center">
-        <span className="text-lg leading-none drop-shadow-sm">{typeIcon[cell.type]}</span>
-        <span className="text-xl font-semibold drop-shadow-md">{cell.units}</span>
-        <span className="text-xs uppercase tracking-wide text-slate-200/80">
-          {cell.owner === "player" && "Comandante"}
-          {cell.owner === "ai" && "IA"}
-          {!cell.owner && (cell.type === "resource" ? "Risorsa" : "Neutrale")}
+      <div className="flex h-full w-full flex-col items-center justify-between gap-1.5 p-1 text-center sm:gap-2 sm:p-2">
+        {icon && (
+          <span className="text-base leading-none drop-shadow-sm sm:text-lg">{icon}</span>
+        )}
+        <span className="text-lg font-semibold leading-tight drop-shadow-md sm:text-2xl">
+          {cell.units}
+        </span>
+        <span className="text-[0.6rem] uppercase tracking-wide text-slate-200/80 leading-tight sm:text-xs">
+          <span className="block w-full truncate">{ownerLabel}</span>
         </span>
       </div>
     </button>

--- a/src/components/GameGrid.tsx
+++ b/src/components/GameGrid.tsx
@@ -12,7 +12,7 @@ interface GameGridProps {
 export function GameGrid({ cells, gridSize, selectedCellId, lastAction, onCellClick }: GameGridProps) {
   return (
     <div
-      className="grid w-full max-w-4xl gap-2 rounded-2xl bg-slate-900/60 p-3 shadow-lg backdrop-blur"
+      className="grid w-full max-w-4xl gap-1.5 rounded-2xl bg-slate-900/60 p-2 shadow-lg backdrop-blur sm:gap-2 sm:p-3"
       style={{ gridTemplateColumns: `repeat(${gridSize}, minmax(0, 1fr))` }}
     >
       {cells.map((cell) => (


### PR DESCRIPTION
## Summary
- refine cell tile layout to better balance icons, unit counts, and owner labels on small screens
- adjust grid padding and spacing to give each tile more room on mobile devices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e42a1a33548330a10a670e7a944ae5