### PR TITLE
Fix build error in CellTile component

### DIFF
--- a/src/components/CellTile.tsx
+++ b/src/components/CellTile.tsx
@@ -35,7 +35,6 @@ const specializationInfo = {
   },
 } as const;
 
-export function CellTile({ cell, isSelected, lastAction, onClick }: CellTileProps) {
 export function CellTile({
   cell,
   isSelected,


### PR DESCRIPTION
## Summary
- remove the duplicate CellTile function signature left from resolving a merge conflict
- keep the focus-related className intact so the component compiles again

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4bd16eec4833080df3d3a1e3cc97a