### PR TITLE
Refine grid icon layout and keep unit sidebar persistent

### DIFF
--- a/src/components/CellTile.tsx
+++ b/src/components/CellTile.tsx
@@ -112,26 +112,33 @@ export function CellTile({
       )}
       title={title || undefined}
     >
-      <div className="flex h-full w-full flex-col items-center justify-between gap-1.5 p-1 text-center sm:gap-2 sm:p-2">
-        {specialization && (
-          <span className="flex items-center gap-1 text-xs font-semibold text-amber-200 drop-shadow-sm">
-            <span>{specialization.icon}</span>
-            <span className="hidden sm:inline">{specialization.label}</span>
-          </span>
-        )}
-        {icon && <span className="text-base leading-none drop-shadow-sm sm:text-lg">{icon}</span>}
+      {icon && (
+        <span className="absolute left-1 top-1 inline-flex items-center justify-center rounded-md bg-slate-950/60 px-1.5 py-1 text-[0.65rem] text-slate-100 shadow-sm ring-1 ring-white/10 sm:left-1.5 sm:top-1.5 sm:text-xs">
+          {icon}
+        </span>
+      )}
+      {specialization && (
+        <span
+          className="absolute right-1 top-1 inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-1.5 py-0.5 text-[0.55rem] font-semibold text-amber-100 shadow-sm ring-1 ring-amber-200/20 sm:right-1.5 sm:top-1.5"
+          title={`${specialization.label}: ${specialization.description}`}
+        >
+          <span>{specialization.icon}</span>
+          <span className="hidden sm:inline">{specialization.label}</span>
+        </span>
+      )}
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-2 pb-3 pt-5 text-center sm:gap-3 sm:px-3 sm:pb-4 sm:pt-6">
         <div className="flex flex-col items-center gap-1">
           <span className="text-lg font-semibold leading-tight drop-shadow-md sm:text-2xl">
             {stackSize > 0 ? `${stackSize}×` : "—"}
           </span>
           {stackSize > 0 && (
-            <span className="rounded-full bg-slate-900/40 px-2 py-0.5 text-[0.6rem] uppercase tracking-wide text-slate-200/80 sm:text-xs">
+            <span className="rounded-full bg-slate-950/50 px-2 py-0.5 text-[0.6rem] uppercase tracking-wide text-slate-200/90 shadow-sm sm:text-xs">
               {soldierCount} soldati
             </span>
           )}
         </div>
-        <span className="text-[0.6rem] uppercase tracking-wide text-slate-200/80 leading-tight sm:text-xs">
-          <span className="block w-full truncate">{ownerLabel}</span>
+        <span className="w-full truncate text-[0.55rem] uppercase tracking-wide text-slate-200/70 drop-shadow-sm sm:text-[0.65rem]">
+          {ownerLabel}
         </span>
       </div>
     </button>

--- a/src/components/SelectedBattalionPanel.tsx
+++ b/src/components/SelectedBattalionPanel.tsx
@@ -11,57 +11,57 @@ export function SelectedBattalionPanel({
   selectedBattalionId,
   onSelectBattalion,
 }: SelectedBattalionPanelProps) {
-  if (!cell || cell.owner !== "player") {
-    return null;
-  }
-
-  const battalions = cell.battalions.filter((unit) => unit.owner === "player");
-  if (battalions.length === 0) {
-    return null;
-  }
+  const battalions =
+    cell?.owner === "player"
+      ? cell.battalions.filter((unit) => unit.owner === "player")
+      : [];
 
   return (
     <aside className="w-full max-w-xs shrink-0 rounded-2xl border border-slate-800 bg-slate-900/60 p-4 shadow-lg backdrop-blur">
-      <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">
-        Unità selezionate
-      </h3>
-      <p className="mt-1 text-xs text-slate-400">
-        Scegli quale battaglione controllare in questa cella.
-      </p>
-      <ul className="mt-3 flex flex-col gap-2">
-        {battalions.map((unit) => {
-          const isSelected = unit.id === selectedBattalionId;
-          const canMove = unit.movementLeft > 0;
-          return (
-            <li key={unit.id}>
-              <button
-                type="button"
-                onClick={() => onSelectBattalion(unit.id)}
-                className={`w-full rounded-xl border p-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
-                  isSelected
-                    ? "border-emerald-400/80 bg-emerald-400/10"
-                    : "border-slate-700/80 bg-slate-900/80 hover:border-emerald-400/60"
-                }`}
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-semibold uppercase tracking-wide text-slate-100">
-                    {unit.type}
-                  </span>
-                  <span className="text-xs font-medium text-slate-300">
-                    {canMove ? "Pronto a muoversi" : "Movimento esaurito"}
-                  </span>
-                </div>
-                <div className="mt-1 text-xs text-slate-300">
-                  Soldati: {unit.soldiers} · Att {unit.attack} · Dif {unit.defense}
-                </div>
-                <div className="mt-1 text-xs text-slate-400">
-                  Movimento: {unit.movementLeft}/{unit.maxMovement}
-                </div>
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+      {battalions.length > 0 && (
+        <>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">
+            Unità selezionate
+          </h3>
+          <p className="mt-1 text-xs text-slate-400">
+            Scegli quale battaglione controllare in questa cella.
+          </p>
+          <ul className="mt-3 flex flex-col gap-2">
+            {battalions.map((unit) => {
+              const isSelected = unit.id === selectedBattalionId;
+              const canMove = unit.movementLeft > 0;
+              return (
+                <li key={unit.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelectBattalion(unit.id)}
+                    className={`w-full rounded-xl border p-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
+                      isSelected
+                        ? "border-emerald-400/80 bg-emerald-400/10"
+                        : "border-slate-700/80 bg-slate-900/80 hover:border-emerald-400/60"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-semibold uppercase tracking-wide text-slate-100">
+                        {unit.type}
+                      </span>
+                      <span className="text-xs font-medium text-slate-300">
+                        {canMove ? "Pronto a muoversi" : "Movimento esaurito"}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-xs text-slate-300">
+                      Soldati: {unit.soldiers} · Att {unit.attack} · Dif {unit.defense}
+                    </div>
+                    <div className="mt-1 text-xs text-slate-400">
+                      Movimento: {unit.movementLeft}/{unit.maxMovement}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- reposition grid cell icons into compact corner badges and rebalance interior spacing for better readability
- keep the selected unit sidebar mounted even without a player selection to provide a persistent info area

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4dd74a0f88330943dd5ed664f8fa7