### PR TITLE
Allow deselecting a cell by clicking it again

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ export default function App() {
       if (cell.type === "base" && cell.owner === "player") {
         actions.produceAt(cell.id, handleUnitPrompt);
       }
+      actions.clearSelection();
       return;
     }
 


### PR DESCRIPTION
## Summary
- allow clicking a selected cell again to clear the current selection so other cells can be targeted
- keep the ability to produce units from bases while clearing the selection afterwards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4e16a06d48330a006d47852ccaaa8